### PR TITLE
ci: deploy and release on every commit to main (mirror konserve)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,23 +67,19 @@ jobs:
 workflows:
   build-test-and-deploy:
     jobs:
-      - format:
-          filters: {tags: {only: /.*/}}
-      - jvm-test:
-          filters: {tags: {only: /.*/}}
-      - cljs-test:
-          filters: {tags: {only: /.*/}}
-      - jar:
-          filters: {tags: {only: /.*/}}
+      - format
+      - jvm-test
+      - cljs-test
+      - jar
       - deploy:
           context: clojars-deploy
           filters:
-            branches: {ignore: /.*/}
-            tags: {only: /^v.*/}
+            branches:
+              only: main
           requires: [format, jvm-test, cljs-test, jar]
       - release:
           context: github-token
           filters:
-            branches: {ignore: /.*/}
-            tags: {only: /^v.*/}
+            branches:
+              only: main
           requires: [deploy]


### PR DESCRIPTION
Mirror konserve's / datahike's continuous-release model: land changes through PRs, and every merge to `main` publishes.

## Change
The `deploy` (Clojars) and `release` (GitHub release + jar) jobs move from version-tag-gated to `branches: {only: main}` — exactly konserve's gating. Tests (`format`, `jvm-test`, `cljs-test`) and `jar` run on all branches (PR validation); `deploy`/`release` run only on `main`. Version is `0.1.<git-rev-count>` (via `build.clj`), so each merge bumps the patch.

## Before merging — prerequisites (CircleCI side, one-time)
- The **`replikativ/geschichte` project must be followed** in CircleCI so it reads this config.
- Contexts must exist and be accessible: **`clojars-deploy`** (`CLOJARS_USERNAME`/`CLOJARS_PASSWORD`) and **`github-token`** (`GITHUB_TOKEN`) — shared with the other replikativ repos.
- The Clojars deploy account is a member of the `org.replikativ` group (it publishes datahike), so the new `geschichte` artifact can be created.

Once merged, this merge itself becomes the first continuous release (`0.1.x` to Clojars + a GitHub release).

## Native binaries — a coupling to decide
`release` creates a `v0.1.<n>` GitHub release/tag per merge. The existing `.github/workflows/native-image.yml` triggers on `push: tags: ['v*']`, so it will build the three GraalVM binaries and attach them to each release — i.e. **native builds per merge**. If you'd rather build native only for milestone releases, we gate that workflow separately (e.g. a `release-*` tag or `workflow_dispatch`) in a follow-up — say the word. This PR leaves `native-image.yml` unchanged.