### PR TITLE
fix: disable Datahike value-size caps for the repository store

### DIFF
--- a/src/geschichte/projection.clj
+++ b/src/geschichte/projection.clj
@@ -68,6 +68,13 @@
    ;; persistent-set nodes per cache layer.
    :store-cache-size 256
    :search-cache-size 0
+   ;; Value-size caps are OPT-IN in Datahike; leaving them unset warns at
+   ;; create. Geschichte stores arbitrary Git content (blobs of any size), so it
+   ;; deliberately disables the caps (0 = unbounded) — content is sized by
+   ;; content-defined chunking and deltas, not by a per-value length limit.
+   :max-string-length 0
+   :max-bytes-length 0
+   :max-tuple-string-length 0
    :schema-flexibility :write
    :keep-history? true
    :commit-graph? true})


### PR DESCRIPTION
## Problem
The native smoke test (`clojure -T:build native-smoke`) started failing after the bump to Datahike 0.8.1743. That release warns at `create-database` when value-size caps are unset:

```
:warn datahike.writing :datahike/value-caps-unset No value-size caps set — …
```

The smoke script (`script/native-smoke.sh`) asserts on exact command output, including `test -z "$("$ges" status --short)"` (empty stdout expected). The new warning, emitted whenever the store is created, breaks that assertion.

## Fix
Set the caps **explicitly to `0` (disabled/unbounded)** in `projection/default-config`:

```clojure
:max-string-length 0
:max-bytes-length 0
:max-tuple-string-length 0
```

geschichte stores arbitrary Git content (blobs of any size), so the caps *must not* bound values — the 4096-char `:value-caps :default` preset would `:transact/max-length`-reject any file over 4 KB. Content is already sized by content-defined chunking and deltas, not a per-value length limit. Setting the caps to `0` is the Datahike-sanctioned way to make the "unbounded" choice explicit and silence the warning.

## Verified
- Reproduced: a fresh store without caps warns; with `:max-string-length 0` etc. it's silent.
- A 100,000-char value still transacts (unbounded preserved — no truncation/rejection).
- JVM suite: 102 tests / 3053 assertions / 0 failures; cljfmt clean.
- The native workflow on this PR should now pass its smoke test.

_(Separate from the native-image build timeouts on the macOS runners, which look like a CI-resource/compile-time issue, not a code failure — happy to dig into those logs next.)_