### PR TITLE
ci: make native smoke test failures diagnosable

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   native-cli:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-24.04

--- a/build.clj
+++ b/build.clj
@@ -85,7 +85,14 @@
     (println output)))
 
 (defn native-smoke [{:keys [executable] :or {executable "./ges"}}]
-  (let [result (b/process {:command-args ["bash" "script/native-smoke.sh"
-                                          executable]})]
+  ;; `-x` traces every command so a failing assertion is visible in the log
+  ;; (a bare `test` prints nothing on failure); capture + echo so the trace is
+  ;; always shown, including in CI.
+  (let [result (b/process {:command-args ["bash" "-x" "script/native-smoke.sh"
+                                          executable]
+                           :out :capture :err :capture})]
+    (some-> (:out result) print)
+    (some-> (:err result) print)
+    (flush)
     (when-not (zero? (:exit result))
-      (throw (ex-info "Native smoke test failed" result)))))
+      (throw (ex-info "Native smoke test failed" {:exit (:exit result)})))))

--- a/script/native-smoke.sh
+++ b/script/native-smoke.sh
@@ -2,10 +2,14 @@
 set -euo pipefail
 
 ges="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-workspace="$(mktemp -d "${TMPDIR:-/tmp}/geschichte-native-XXXXXX")"
-agent="$(mktemp -d "${TMPDIR:-/tmp}/geschichte-agent-XXXXXX")"
-native_source="$(mktemp -d "${TMPDIR:-/tmp}/geschichte-git-source-XXXXXX")"
-local_clone="$(mktemp -d "${TMPDIR:-/tmp}/geschichte-local-clone-XXXXXX")"
+# Canonicalise temp dirs: on macOS $TMPDIR (/var/folders/…) is a symlink to
+# /private/var/…, and `rev-parse --show-toplevel` returns the resolved path, so
+# a raw mktemp path would not compare equal. `pwd -P` resolves the symlink.
+mktmp() { cd "$(mktemp -d "${TMPDIR:-/tmp}/$1-XXXXXX")" && pwd -P; }
+workspace="$(mktmp geschichte-native)"
+agent="$(mktmp geschichte-agent)"
+native_source="$(mktmp geschichte-git-source)"
+local_clone="$(mktmp geschichte-local-clone)"
 trap 'rm -rf "$workspace" "$agent" "$native_source" "$local_clone"' EXIT
 
 cd "$workspace"


### PR DESCRIPTION
The native smoke test passes on Linux (verified locally: exit 0, clean output) but fails on **macOS** in ~4 s, and the failure is currently invisible:

- `build.clj` discarded the script's stdout/stderr (only the wrapper exception reached the log).
- A bare `test "$(…)" = "…"` assertion prints nothing when it fails.
- `fail-fast` (default) cancels the other OS jobs the moment one fails, which read as "timeouts".

This PR makes it diagnosable, without touching behaviour:
- run `script/native-smoke.sh` under **`bash -x`** and **capture+echo** the output, so the trace (and the exact failing assertion) appears in the log;
- **`fail-fast: false`** on the native matrix so all three OSes report.

`native-image.yml` runs on `pull_request`, so this PR's run will surface the macOS trace — no release/tag needed. Once we can see the failing line, the real fix is a follow-up.