### PR TITLE
docs: konserve-style badges, ges CLI examples, beta notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # geschichte
 
+[![Slack](https://img.shields.io/badge/slack-join_chat-brightgreen.svg)](https://clojurians.slack.com/archives/CB7GJAN0L)
 [![Clojars](https://img.shields.io/clojars/v/org.replikativ/geschichte.svg)](https://clojars.org/org.replikativ/geschichte)
 [![CircleCI](https://circleci.com/gh/replikativ/geschichte.svg?style=shield)](https://circleci.com/gh/replikativ/geschichte)
-[![Slack](https://img.shields.io/badge/slack-join_chat-brightgreen.svg)](https://clojurians.slack.com/archives/C09622F337D)
+[![last-commit](https://img.shields.io/github/last-commit/replikativ/geschichte/main.svg)](https://github.com/replikativ/geschichte)
 
 **Git, as a queryable database.**
 
@@ -19,6 +20,10 @@ combination no other system provides — see [Prior art](doc/prior-art.md).
 
 It is a new implementation in the lineage of the original *geschichte* project,
 which became replikativ.
+
+> **Beta.** geschichte is usable but pre-1.0. On-disk and database formats may
+> still change between releases; you may need to re-import or migrate
+> repositories as it stabilises.
 
 ## Why geschichte?
 
@@ -93,13 +98,16 @@ See [Getting started](doc/getting-started.md) and the
 geschichte-specific inspection under its own namespaces:
 
 ```sh
-clojure -M:cli -- init
-clojure -M:cli -- status --short
-clojure -M:cli -- add -A
-clojure -M:cli -- commit -m initial
-clojure -M:cli -- log --oneline
-clojure -M:cli -- db query '[:find ?path :where [?e :geschichte.work/path ?path]]'
+ges init
+ges status --short
+ges add -A
+ges commit -m initial
+ges log --oneline
+ges db query '[:find ?path :where [?e :geschichte.work/path ?path]]'
 ```
+
+From a source checkout, replace `ges` with `clojure -M:cli --`
+(e.g. `clojure -M:cli -- status --short`).
 
 Tagged releases ship native `ges` archives for Linux amd64, macOS arm64, and
 macOS amd64. See the [CLI guide](doc/cli.md).

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -3,10 +3,12 @@
 The JVM entrypoint is `geschichte.cli`; native releases package it as `ges`.
 
 ```sh
-clojure -M:cli -- --help
-clojure -M:cli -- status --help
+ges --help
 ges status --help
 ```
+
+From a source checkout, run the same commands as `clojure -M:cli -- …`
+(e.g. `clojure -M:cli -- status --help`).
 
 Git-compatible commands are top-level. `ges git …` remains an alias for tools
 that insist on a Git-shaped wrapper. Per-command help validates the same option


### PR DESCRIPTION
- **Badges** now match konserve's set — Slack, Clojars, CircleCI, and a `last-commit` badge. The Clojars badge image was blank only because the artifact wasn't published yet; it renders now (0.1.5 is on Clojars).
- **CLI examples use `ges`** (the shipped native command) instead of the `clojure -M:cli --` long form, with a one-line note for running from a source checkout.
- **Beta notice**: geschichte is usable but pre-1.0 — on-disk and database formats may change between releases, and repositories may need re-import/migration as it stabilises.

Note: I pointed the Slack badge at konserve's Clojurians channel (`CB7GJAN0L`), replacing the previous `C09622F337D` per "same as konserve" — switch it back if geschichte has its own channel.