### PR TITLE
ci: set GH_REPO in the native release job

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Attach native archives to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job does not check out the repo, so tell gh which repo to use
+          # (otherwise it errors with "not a git repository").
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || \
             gh release create "${GITHUB_REF_NAME}" --verify-tag --generate-notes


### PR DESCRIPTION
The native builds now pass on all three OSes, so the `release` job (which attaches the native archives to the GitHub release) finally runs — and fails:

```
gh release view "${GITHUB_REF_NAME}" …
failed to run git: fatal: not a git repository
```

That job downloads artifacts but doesn't `actions/checkout`, so `gh` has no local repo to infer from. Set `GH_REPO: ${{ github.repository }}` in the job env so `gh` resolves the repo from the environment — no checkout needed. (The GitHub release itself is created by the CircleCI `release` job on the same tag; this job just uploads the native tarballs to it.)