### PR TITLE
feat(code): semantic + syntactic code search over a repository

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,9 @@
         org.replikativ/konserve  {:mvn/version "0.9.362"}
         is.simm/partial-cps      {:mvn/version "0.1.60"}
         org.clojure/core.async   {:mvn/version "1.6.681"}
-        org.clojure/tools.cli    {:mvn/version "1.1.230"}}
+        org.clojure/tools.cli    {:mvn/version "1.1.230"}
+        ;; geschichte.code splits Clojure source into top-level forms
+        org.clojure/tools.reader {:mvn/version "1.5.2"}}
 
  :aliases
  {:test {:extra-paths ["test"]
@@ -55,6 +57,23 @@
   {:extra-deps {org.replikativ/yggdrasil {:local/root "../yggdrasil"}}}
 
   :cli {:main-opts ["-m" "geschichte.cli"]}
+
+  ;; Semantic code search (geschichte.code.embed): embeddings → Proximum KNN as
+  ;; a Datalog clause. Needs a Datahike with :db.type/float-array + the
+  ;; external-engine query-spec-fn (≥ 0.8.1746) and Java 22+ (Proximum's HNSW).
+  ;; The bridge ns datahike.index.secondary.proximum ships in the datahike jar.
+  ;; Bring your own embedder (any (fn [texts] -> [float[]])).
+  :embed {:override-deps {org.replikativ/datahike {:mvn/version "0.8.1746"}
+                          ;; float-array content-addressing (:db.secondary/only)
+                          ;; needs hasch's float[]/double[] coercion (≥ 0.4.102);
+                          ;; geschichte's core pin is older.
+                          org.replikativ/hasch {:mvn/version "0.4.102"}}
+          :extra-deps {org.replikativ/proximum {:mvn/version "0.1.25"}}
+          :jvm-opts ["--add-modules" "jdk.incubator.vector"
+                     "--enable-native-access=ALL-UNNAMED"]}
+
+  ;; Deep structural (syntactic) queries (geschichte.code.ast) via tools.analyzer.
+  :ast {:extra-deps {org.clojure/tools.analyzer.jvm {:mvn/version "1.3.2"}}}
 
   :native-runtime
   {:override-deps

--- a/doc/code-search.md
+++ b/doc/code-search.md
@@ -1,0 +1,155 @@
+# Semantic + syntactic code search
+
+A geschichte repository is a Datahike database — its commit DAG, refs and file
+contents are datoms (see [Querying](querying.md)). `geschichte.code` adds a code
+model over them: each **top-level form** of every Clojure file version becomes an
+entity, and you query code the same way you query the commit graph. Three kinds
+of matching compose in one Datalog query:
+
+| layer | namespace | how it matches | needs |
+|---|---|---|---|
+| **structural (callsites)** | `geschichte.code` | forms that *call* X | — (core) |
+| **semantic** | `geschichte.code.embed` | forms *like* X (embedding KNN) | `:embed` alias |
+| **structural (AST)** | `geschichte.code.ast` | forms with a control-flow *shape* | `:ast` alias |
+
+…and every match joins back to the commit DAG — who wrote it, when, whether it
+still exists at HEAD.
+
+## Relation to Datomic codeq
+
+[codeq](https://github.com/Datomic/codeq) (Rich Hickey, 2012) turns git history
+into Datomic datoms and tracks **definitions across time** with source, location
+and callsites. `geschichte.code` is the same idea on Datahike — `:code.form/*`
+is codeq's def, `:code.form/calls` its callsites — with two things codeq never
+had: forms are **content-addressed** (a form unchanged across N commits is one
+entity, so you get de-duplication for free), and a **semantic** layer
+(embeddings → nearest-neighbour search) sits alongside the syntactic one.
+
+## Content addressing
+
+The key move: a form's identity is the SHA-1 of its source text
+(`:code.form/hash`, `:db.unique/identity`). On a full import of Clojure's history
+that collapses **396,675 form instances → 10,090 distinct forms (38.7×)** — you
+embed and analyze each distinct form once, and it carries its whole cross-commit
+lifetime through `:code.occurrence/*`.
+
+## Ingesting
+
+Walk the repository's Clojure blobs and feed their source to `transact-forms!`.
+Each source is `{:text <string> :path <string> :commit <commit-eid>}`; non-Clojure
+files are skipped (`clojure-file?`).
+
+```clojure
+(require '[geschichte.code :as code]
+         '[datahike.api :as d])
+
+(d/transact conn code/schema)
+
+;; `sources` — one entry per (commit, Clojure-blob). Producing it is a walk over
+;; the repo's content; the shape is all `transact-forms!` needs:
+(code/transact-forms! conn sources)
+;; => {:forms 10090 :occurrences 396675}
+```
+
+Forms are de-duplicated by content hash (re-seeing a form is a no-op upsert);
+each (form, commit, path) becomes one `:code.occurrence`.
+
+## Layer 1 — structural (callsites), core
+
+`:code.form/calls` holds the symbols each form invokes — codeq-style, cheap, no
+analyzer. "Which forms call `swap!`?" is one clause:
+
+```clojure
+(d/q '[:find [?name ...] :where
+       [?e :code.form/calls "swap!"] [?e :code.form/name ?name]]
+     @conn)
+```
+
+## Layer 2 — semantic (embedding KNN), `:embed`
+
+Embed each distinct form and index the vectors in
+[Proximum](https://github.com/replikativ/proximum); a nearest-neighbour search is
+then a Datalog `:where` clause (no manual bitset plumbing — via datahike's
+external-engine query-spec-fn). The embedder is **pluggable** — any
+`(fn [texts] -> [float[]])`;
+[pretrained-rstr](https://github.com/replikativ/pretrained-rstr) is one.
+
+```clojure
+(require '[geschichte.code.embed :as embed])
+
+(d/transact conn (embed/embedding-schema))
+(d/transact conn (embed/index-declaration
+                  {:dim 384 :capacity 20000
+                   :store-config {:backend :file :path "/tmp/code-vectors"
+                                  :id (random-uuid)}}))
+(embed/index! conn my-embed-fn)          ; embeds forms lacking an embedding
+```
+
+Now KNN is a clause. Two binding shapes: `[?e]` (filter — entities only) and
+`[[?e ?distance]]` (retrieval — entity + cosine distance):
+
+```clojure
+;; nearest to a query vector, joined to provenance
+(d/q '[:find ?name ?distance
+       :in $ ?qvec
+       :where
+       [(datahike.index.secondary.proximum/knn :code/embeddings ?qvec 10) [[?e ?distance]]]
+       [?e :code.form/name ?name]]
+     @conn (my-embed-fn ["reduce a collection to a single value"]))
+```
+
+### Semantic × syntactic — one query
+
+The clause composes with the callsite layer. "Reduce-like code that uses an
+explicit `loop`" — semantics find the family, syntax picks the imperative ones:
+
+```clojure
+(d/q '[:find [?name ...]
+       :in $ ?qvec
+       :where
+       [(datahike.index.secondary.proximum/knn :code/embeddings ?qvec 50) [?e ...]]
+       [?e :code.form/calls "loop"]
+       [?e :code.form/name ?name]]
+     @conn reduce-vec)
+;; => on Clojure's history: iter-reduce, iterator-reduce!, …
+```
+
+### Semantic × temporal — dead ends
+
+Restrict the neighbourhood to forms **absent from HEAD** — abandoned work similar
+to a query, the "what were the dead ends" question. Compute the live set from the
+commit graph, then use it as a Datalog constraint. On Clojure's history, the
+nearest abandoned neighbours of the modern `reduce` are Rich Hickey's 2008–2009
+hand-recursive implementations.
+
+## Layer 3 — structural (AST), `:ast`
+
+`:code.form/calls` is callsites; `geschichte.code.ast` goes to full control-flow
+structure via `tools.analyzer` — `:loop`/`:recur`/`:if` presence and counts.
+Analysis is heavier and can fail on forms referencing unresolvable host classes,
+so run it **on-demand over a small result set** (a KNN neighbourhood), not as a
+full index:
+
+```clojure
+(require '[geschichte.code.ast :as ast])
+
+;; classify a semantic neighbourhood by implementation strategy
+(for [{:keys [e name]} (embed/nearest @conn :code/embeddings reduce-vec 12)]
+  (assoc (ast/shape-of @conn e) :name name))
+;; => {:name "iter-reduce" :loop? true  :recur? true  :if 5 …}   ; imperative loop
+;;    {:name "reduce"      :loop? false :recur? true  :if 2 …}   ; tail-recursive
+;;    {:name "seq-reduce"  :loop? false :recur? false :if 1 …}   ; delegating
+```
+
+`ast/analyze` isolates `tools.analyzer.jvm`'s var-interning to a throwaway
+namespace, so analyzing corpus code like `(defn map …)` never clobbers
+`clojure.core` in your namespace.
+
+## Why one store
+
+None of these are expressible alone: Git has no joins, a vector database has no
+ancestry, plain Datalog has no fuzzy similarity, and an AST index has no
+semantics. Because a geschichte repository *is* a Datahike database, KNN, Datalog
+joins, the commit DAG, and the AST live in one query engine — you ask for
+"abandoned code semantically near this, that manually recurs, and who wrote it"
+as a single query.

--- a/src/geschichte/code.clj
+++ b/src/geschichte/code.clj
@@ -1,0 +1,206 @@
+(ns geschichte.code
+  "Code objects over a geschichte repository — the queryable, versioned code
+  model.
+
+  A geschichte repository is a Datahike database, so its commit DAG, refs and
+  file contents are already datoms (see doc/querying.md). This namespace adds a
+  thin layer above them: each top-level *form* of every Clojure file version
+  becomes an entity, **content-addressed** by the hash of its source text, so a
+  form unchanged across N commits is one entity — the same content-addressing
+  geschichte uses for blobs, one level down. Occurrences link a form to the
+  commit(s) that carried it, so a form has provenance in the DAG.
+
+  This is close in spirit to Datomic's codeq (git history → datoms, definitions
+  tracked across time): `:code.form/*` is codeq's def, and `:code.form/calls` is
+  its callsites. Two capabilities geschichte adds on top live in optional
+  namespaces:
+
+    - `geschichte.code.embed` — semantic search (embeddings → Proximum KNN,
+      callable as a Datalog clause). Needs `org.replikativ/proximum` and a
+      Datahike with `:db.type/float-array` + the external-engine query-spec-fn.
+    - `geschichte.code.ast` — deep structural queries via tools.analyzer.
+
+  The core here (this namespace) has no optional dependencies: form splitting,
+  content-addressing, and callsite extraction give codeq-style syntactic search
+  out of the box."
+  (:require [clojure.string :as str]
+            [clojure.tools.reader :as r]
+            [clojure.tools.reader.reader-types :as rt]
+            [datahike.api :as d])
+  (:import [java.security MessageDigest]))
+
+;; ---------------------------------------------------------------------------
+;; Schema
+
+(def schema
+  "Datahike schema for the code layer. Transact once into a geschichte repo
+  connection. `geschichte.code.embed/schema` adds the embedding attribute."
+  [;; A distinct top-level form, keyed by the hash of its source text. Identical
+   ;; text across commits collapses to one entity (and, downstream, one
+   ;; embedding / one AST).
+   {:db/ident :code.form/hash
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :code.form/kind          ; :defn :def :ns :deftest :defmacro …
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :code.form/name          ; best-effort defined name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :code.form/text          ; verbatim source
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   ;; Symbols the form invokes (call position). Codeq-style callsites — cheap,
+   ;; robust, needs no analyzer: powers "which forms call X".
+   {:db/ident :code.form/calls
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/many}
+
+   ;; A form appeared at a path in a commit. Reified so path + commit travel
+   ;; together; this is the join from a form to the commit DAG.
+   {:db/ident :code.occurrence/form
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :code.occurrence/commit  ; -> a :geschichte.commit entity
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :code.occurrence/path
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+;; ---------------------------------------------------------------------------
+;; File selection — Clojure only
+
+(def clojure-extensions #{"clj" "cljc" "cljs" "cljd" "bb" "edn"})
+
+(defn clojure-file?
+  "True iff `path` names a Clojure source file we can split into forms.
+  Non-Clojure files are skipped — the analyzer/reader only understand Clojure,
+  and splitting arbitrary text into 'forms' is meaningless."
+  [path]
+  (when-let [ext (second (re-find #"\.([^.]+)$" (str path)))]
+    (contains? clojure-extensions (str/lower-case ext))))
+
+;; ---------------------------------------------------------------------------
+;; Form splitting — verbatim source slices
+
+(defn- form-name [form]
+  (when (and (seq? form) (>= (count form) 2))
+    (let [op (first form) nm (second form)]
+      (when (and (symbol? op) (symbol? nm)) (str nm)))))
+
+(defn- form-kind [form]
+  (when (and (seq? form) (symbol? (first form)))
+    (keyword (name (first form)))))
+
+(defn split-forms
+  "Split Clojure source `text` into its top-level forms, returning
+  `[{:kind :name :text :line} …]`.
+
+  Reads with position tracking, then slices the ORIGINAL source lines so the
+  stored text is the real source (comments, formatting) rather than a printed
+  round-trip of the read data. Reader-conditionals are preserved (`:read-cond
+  :preserve`); an unreadable file yields an empty vector."
+  [text]
+  (let [lines (vec (str/split-lines text))
+        rdr (rt/indexing-push-back-reader text)
+        eof (Object.)]
+    (loop [acc [], start-line 1]
+      (let [form (try (binding [r/*read-eval* false]
+                        (r/read {:eof eof :read-cond :preserve} rdr))
+                      (catch Exception _ eof))]
+        (if (identical? form eof)
+          acc
+          (let [end-line (rt/get-line-number rdr)
+                slice (str/join "\n" (subvec lines
+                                             (max 0 (dec start-line))
+                                             (min (count lines) end-line)))]
+            (recur (if (str/blank? slice)
+                     acc
+                     (conj acc {:kind (form-kind form)
+                                :name (form-name form)
+                                :line start-line
+                                :text slice}))
+                   (inc end-line))))))))
+
+;; ---------------------------------------------------------------------------
+;; Content addressing + callsites
+
+(defn form-hash
+  "Hex SHA-1 of a form's source text — its content-addressed identity."
+  [^String text]
+  (let [md (MessageDigest/getInstance "SHA-1")]
+    (->> (.digest md (.getBytes text "UTF-8"))
+         (map #(format "%02x" (bit-and % 0xff)))
+         (apply str))))
+
+(defn called-symbols
+  "The set of symbol names in call position anywhere in `form` (recursively) —
+  the form's callsites. Read `text` with `read-form` first."
+  [form]
+  (let [acc (java.util.HashSet.)]
+    (letfn [(walk [x]
+              (cond
+                (seq? x) (do (when (symbol? (first x)) (.add acc (name (first x))))
+                             (doseq [e x] (walk e)))
+                (coll? x) (doseq [e x] (walk e))))]
+      (walk form))
+    (set acc)))
+
+(defn read-form
+  "Read one form from `text` for structural inspection (callsites), or nil if it
+  cannot be read. Never evals."
+  [text]
+  (try (binding [r/*read-eval* false]
+         (r/read {:eof nil :read-cond :allow :features #{:clj}}
+                 (rt/string-push-back-reader text)))
+       (catch Throwable _ nil)))
+
+(defn form-entity
+  "A form map `{:kind :name :text …}` → a Datahike entity map keyed by content
+  hash, including callsites. Merge extra keys (e.g. an embedding) as needed."
+  [{:keys [kind name text]}]
+  (let [calls (some-> (read-form text) called-symbols)]
+    (cond-> {:code.form/hash (form-hash text)
+             :code.form/text text}
+      kind (assoc :code.form/kind kind)
+      name (assoc :code.form/name name)
+      (seq calls) (assoc :code.form/calls (vec calls)))))
+
+;; ---------------------------------------------------------------------------
+;; Ingestion
+
+(defn transact-forms!
+  "Ingest form sources into a geschichte repo `conn`. `sources` is a seq of
+  `{:text <string> :path <string> :commit <commit-eid>}` — typically produced by
+  walking the repository's Clojure blobs across history (see doc/code-search.md).
+
+  Forms are content-addressed, so re-seeing an identical form is a no-op upsert;
+  each (form, commit, path) becomes one occurrence. Returns
+  `{:forms <n-distinct> :occurrences <n>}`.
+
+  Non-`:code.form/embedding` only — embeddings are added by
+  `geschichte.code.embed/index!`."
+  [conn sources]
+  (let [;; split each source into forms, keep the commit/path with each
+        instances (for [{:keys [text path commit]} sources
+                        :when (string? text)
+                        form (split-forms text)]
+                    (assoc form :path path :commit commit))
+        by-hash (group-by (comp form-hash :text) instances)]
+    ;; forms first (dedup by hash), in batches
+    (doseq [batch (partition-all 500 by-hash)]
+      (d/transact conn (mapv (fn [[_h [f & _]]] (form-entity f)) batch)))
+    ;; then occurrences (need form eids resolved via the unique hash)
+    (let [hash->eid (into {} (d/q '[:find ?h ?e :where [?e :code.form/hash ?h]] @conn))]
+      (doseq [batch (partition-all 5000 instances)]
+        (d/transact conn (into []
+                               (keep (fn [{:keys [text path commit]}]
+                                       (when-let [fe (hash->eid (form-hash text))]
+                                         (when commit
+                                           {:code.occurrence/form fe
+                                            :code.occurrence/commit commit
+                                            :code.occurrence/path path}))))
+                               batch))))
+    {:forms (count by-hash) :occurrences (count instances)}))

--- a/src/geschichte/code/ast.clj
+++ b/src/geschichte/code/ast.clj
@@ -1,0 +1,64 @@
+(ns geschichte.code.ast
+  "Deep structural (syntactic) queries over forms, via tools.analyzer.
+
+  Optional. Requires `org.clojure/tools.analyzer.jvm` (the `:ast` alias).
+
+  `geschichte.code`'s `:code.form/calls` already covers callsites cheaply. This
+  goes further — full control-flow structure (`:loop`/`:recur`/`:if`/… op
+  counts) — at the cost of analyzing each form. Analysis is heavier and can
+  fail on forms that reference unresolvable host classes, so prefer running it
+  **on-demand over a small result set** (a KNN neighbourhood, a Datalog result)
+  rather than indexing every form.
+
+  A subtlety this namespace handles for you: `tools.analyzer.jvm` *interns* the
+  var when it parses a `def` node (to resolve self-references), which would
+  clobber `clojure.core` names in your namespace as it analyzes corpus code like
+  `(defn map …)`. We point the analysis env at a throwaway namespace so the
+  interning lands there instead. `run-passes` is bypassed (`identity`) so no
+  resolution passes run — structural analysis needs none."
+  (:require [clojure.tools.analyzer.jvm :as ana]
+            [clojure.tools.analyzer.ast :as ast]
+            [geschichte.code :as code]
+            [datahike.api :as d]))
+
+(def ^:private sandbox
+  "Throwaway namespace the analyzer interns corpus `def`s into (with core
+  referred so macroexpansion resolves), keeping the caller's ns clean."
+  (delay (let [ns (create-ns (gensym "geschichte.code.ast.sandbox"))]
+           (binding [*ns* ns] (refer-clojure))
+           ns)))
+
+(defn analyze
+  "Analyze a Clojure `form` to a tools.analyzer AST, or nil if it can't be
+  analyzed. Interning is isolated to a sandbox namespace; resolution passes are
+  skipped so it works on forms out of their original context."
+  [form]
+  (try
+    (binding [ana/run-passes identity]
+      (ana/analyze form (assoc (ana/empty-env) :ns (ns-name @sandbox))))
+    (catch Throwable _ nil)))
+
+(defn ops
+  "Frequency map of AST `:op`s in `form`'s text (e.g. `{:invoke 4 :if 2 :loop 1}`),
+  or nil if it can't be analyzed."
+  [text]
+  (when-let [form (code/read-form text)]
+    (when-let [a (analyze form)]
+      (frequencies (map :op (ast/nodes a))))))
+
+(defn shape
+  "A compact structural summary of a form's text — control-flow presence and
+  size — for classifying/filtering a result set:
+  `{:loop? :recur? :if :invoke :nodes}`. nil if unanalyzable."
+  [text]
+  (when-let [o (ops text)]
+    {:loop? (contains? o :loop)
+     :recur? (contains? o :recur)
+     :if (get o :if 0)
+     :invoke (get o :invoke 0)
+     :nodes (reduce + (vals o))}))
+
+(defn shape-of
+  "Structural shape for a form entity `e` in `db` (reads its `:code.form/text`)."
+  [db e]
+  (some-> (:code.form/text (d/pull db [:code.form/text] e)) shape))

--- a/src/geschichte/code/embed.clj
+++ b/src/geschichte/code/embed.clj
@@ -1,0 +1,105 @@
+(ns geschichte.code.embed
+  "Semantic layer over `geschichte.code`: embed each distinct form and index the
+  vectors in Proximum, so nearest-neighbour search is a Datalog `:where` clause.
+
+  Optional. Requires:
+    - `org.replikativ/proximum` on the classpath, and its bridge
+      `datahike.index.secondary.proximum` (datahike's `src-secondary`), via the
+      `:embed` alias;
+    - a Datahike with `:db.type/float-array` and the external-engine
+      query-spec-fn (≥ 0.8.1746), so a `float[]` is a first-class value and
+      `proximum/knn` is a clause;
+    - Java 22+ (Proximum's HNSW).
+
+  The embedder is *pluggable* — pass any `(fn [texts] -> seq-of-float[])`; this
+  namespace has no dependency on a particular model. `org.replikativ/pretrained-rstr`
+  is one such embedder (`emb/embed-texts`)."
+  (:require [datahike.api :as d]
+            ;; loading the bridge registers the :proximum secondary index type
+            ;; and the `knn` external-engine clause fn
+            [datahike.index.secondary.proximum :as prox]))
+
+;; ---------------------------------------------------------------------------
+;; Schema
+
+(defn embedding-schema
+  "The embedding attribute. `:db.secondary/only` keeps the (large) vector out of
+  the primary index — it lives only in the covering Proximum index; the primary
+  holds a content hash. `dim` must match your embedder's output width."
+  []
+  [{:db/ident :code.form/embedding
+    :db/valueType :db.type/float-array
+    :db/cardinality :db.cardinality/one
+    :db.secondary/only true}])
+
+(defn index-declaration
+  "Schema datom declaring a Proximum HNSW secondary index over
+  `:code.form/embedding`. Transact after `embedding-schema`. Options:
+  `:idx-ident` (default :code/embeddings), `:dim` (required), `:distance`
+  (default :cosine), `:capacity`, `:store-config` (a konserve store config —
+  a `:file` backend keeps the heap small; **`:id` UUID is required**)."
+  [{:keys [idx-ident dim distance capacity store-config]
+    :or {idx-ident :code/embeddings distance :cosine}}]
+  [{:db/ident idx-ident
+    :db.secondary/type :proximum
+    :db.secondary/attrs [:code.form/embedding]
+    :db.secondary/config (cond-> {:dim dim :distance distance
+                                  :store-config store-config}
+                           capacity (assoc :capacity capacity))}])
+
+;; ---------------------------------------------------------------------------
+;; Indexing
+
+(defn index!
+  "Embed every form that has no embedding yet and transact the vectors, which
+  the declared Proximum index picks up. `embed-fn` maps a batch of strings to a
+  seq of `float[]` (one per string). Returns the number embedded.
+
+  Call after the forms are ingested (`geschichte.code/transact-forms!`) and the
+  index is declared. Idempotent — only forms missing `:code.form/embedding` are
+  processed, so it resumes cleanly."
+  ([conn embed-fn] (index! conn embed-fn {}))
+  ([conn embed-fn {:keys [batch-size] :or {batch-size 256}}]
+   (let [todo (d/q '[:find ?e ?text
+                     :where [?e :code.form/text ?text]
+                     (not [?e :code.form/embedding _])]
+                   @conn)]
+     (doseq [batch (partition-all batch-size todo)]
+       (let [vecs (embed-fn (mapv second batch))]
+         (d/transact conn (mapv (fn [[e _] v] {:db/id e :code.form/embedding v})
+                                batch vecs))))
+     (count todo))))
+
+;; ---------------------------------------------------------------------------
+;; Query — KNN is a datalog clause (via datahike.index.secondary.proximum/knn)
+
+(defn knn-clause
+  "The `:where` clause form for a KNN search — a convenience so callers needn't
+  spell the fully-qualified symbol. Splice into a query:
+
+    (d/q (into '[:find ?name ?distance :in $ ?qvec :where]
+               [(gc.embed/knn-clause :code/embeddings '?qvec 10 '[[?e ?distance]])
+                '[?e :code.form/name ?name]])
+         db query-vector)
+
+  `binding` is `[?e]` (filter, entities only) or `[[?e ?distance]]` (retrieval,
+  entity + cosine distance). Planner-only — external-engine clauses need the
+  query planner (on by default)."
+  [idx-ident qvec-var k binding]
+  [(list `prox/knn idx-ident qvec-var k) binding])
+
+(defn nearest
+  "Convenience: k forms nearest to `qvec` (a `float[]`), optionally within a
+  Datalog constraint. Returns `[{:e :name :distance} …]` ordered by distance.
+  `extra-where` is spliced after the KNN clause (all vars join on `?e`), e.g.
+  `'[[?e :code.form/calls \"loop\"]]`. For richer results, write the `d/q`
+  directly with `knn-clause`."
+  ([db idx-ident qvec k] (nearest db idx-ident qvec k []))
+  ([db idx-ident qvec k extra-where]
+   (->> (d/q (into [:find '?e '?name '?distance :in '$ '?qvec :where
+                    [(list `prox/knn idx-ident '?qvec k) '[[?e ?distance]]]
+                    '[?e :code.form/name ?name]]
+                   extra-where)
+             db qvec)
+        (map (fn [[e name distance]] {:e e :name name :distance distance}))
+        (sort-by :distance))))


### PR DESCRIPTION
`geschichte.code` models code objects on top of the repository's commit DAG: each top-level Clojure form of every file version becomes an entity, **content-addressed** by the hash of its source text (a form unchanged across N commits is one entity — **38.7× dedup** on Clojure's history), with `:code.occurrence/*` linking a form to the commits that carried it.

Close in spirit to [Datomic codeq](https://github.com/Datomic/codeq) (git history → datoms, definitions tracked across time), on Datahike, with a semantic layer codeq never had.

## Three composable matching layers

| namespace | matches | deps |
|---|---|---|
| `geschichte.code` | callsites — "which forms call X" (`:code.form/calls`) + content-addressing | none (core) |
| `geschichte.code.embed` | semantic — forms *like* X, KNN as a Datalog clause | `:embed` |
| `geschichte.code.ast` | structural — control-flow *shape* (loop/recur/if …) | `:ast` |

All three compose in **one** `d/q`, and every match joins back to the commit DAG (who/when/still-at-HEAD):

```clojure
;; semantic × syntactic: reduce-like code that uses an explicit loop
[(datahike.index.secondary.proximum/knn :code/embeddings ?qvec 50) [?e ...]]
[?e :code.form/calls "loop"]
;; => iter-reduce, iterator-reduce!, …
```

## Design

- **KNN is a `:where` clause** — no `EntityBitSet` plumbing — via datahike's external-engine query-spec-fn (#862) + the Proximum `knn` fn (datahike ≥ 0.8.1746). `embed/nearest` / `embed/knn-clause` wrap it thinly; raw `d/q` works too.
- **Pluggable embedder** — `embed/index!` takes any `(fn [texts] -> [float[]])`; no hard dep on a model. [pretrained-rstr](https://github.com/replikativ/pretrained-rstr) is one.
- **Optional heavy layers** — Proximum and tools.analyzer are alias-gated; the core (syntactic) works with any datahike. Non-Clojure files skipped.
- `geschichte.code.ast` isolates `tools.analyzer.jvm`'s var-interning to a throwaway namespace, so analyzing corpus `(defn map …)` never clobbers `clojure.core`.

## Deps

- `:embed` pins datahike **0.8.1746** (the query-spec-fn + `:db.type/float-array` release) and overrides **hasch 0.4.102** (float-array content-addressing; the core hasch pin is 0.4.101). Java 22+ (Proximum's HNSW).
- Core adds `org.clojure/tools.reader` (form splitting).

## Validation

End-to-end against the **released 0.8.1746** via the `:embed`/`:ast` aliases: ingest → embed/index → `nearest` (semantic ordering) → combined KNN + `:code.form/calls` clause → on-demand `ast/shape-of`. Core + `:ast` are release-independent; only `:embed` needs 1746. `doc/code-search.md` documents the codeq relation and worked queries.