### PR TITLE
Implement GarbageCollectable, and refuse a cutoff that bricks the repository

### DIFF
--- a/src/geschichte/yggdrasil.cljc
+++ b/src/geschichte/yggdrasil.cljc
@@ -202,6 +202,61 @@
                                 :time (:time opts)}))
      this))
 
+  p/GarbageCollectable
+  (gc-roots [_]
+    ;; Every ref tip, as the snapshot it names. These are the git refs whose
+    ;; commits must survive collection.
+    ;; `repo/refs` is {logical-ref -> commit-id-or-nil}; a ref with no target
+    ;; (a freshly created branch) contributes nothing.
+    (->> (repo/refs conn)
+         vals
+         (remove nil?)
+         (keep (fn [cid] (:geschichte.commit/snapshot (repo/commit-by-id conn cid))))
+         (map str)
+         set))
+
+  (gc-sweep! [this snapshot-ids] (p/gc-sweep! this snapshot-ids nil))
+  (gc-sweep! [_ _snapshot-ids opts]
+    ;; Reclaim orphaned Datahike index blobs. Datahike computes its own
+    ;; reachability, so the coordinator's snapshot-ids are ignored — same
+    ;; contract as the datahike adapter.
+    ;;
+    ;; A NON-EPOCH `:remove-before` IS REFUSED, and that is the whole point of
+    ;; this method existing rather than letting the generic adapter run.
+    ;; `:geschichte.commit/snapshot` resolves through `d/commit-as-db`, so a
+    ;; Datahike commit record IS a Git tree — and Datahike follows ancestry only
+    ;; while a record is newer than the cutoff, because its own liveness rule is
+    ;; reachability AND recency. Geschichte's refs are ordinary datoms, invisible
+    ;; to that rule, so every commit looks like unreferenced old history.
+    ;;
+    ;; Measured: three commits plus a non-epoch cutoff reclaimed 75 keys, after
+    ;; which `repo/tree`, `repo/status` and `repo/tree-at` all throw "Geschichte
+    ;; commit names a missing Datahike checkpoint" while `repo/read` still works
+    ;; — a silently half-destroyed repository. Refusing is strictly better than
+    ;; reclaiming and bricking.
+    ;;
+    ;; Epoch (the default) is safe and reclaims writes published to Konserve
+    ;; that no transaction ever made reachable: interrupted pack imports, killed
+    ;; agents, aborted large writes.
+    (let [opts (t/async-gc-opts "geschichte/gc-sweep!" opts)
+          rb   (:remove-before opts)
+          epoch (#?(:clj java.util.Date. :cljs js/Date.) 0)]
+      (when (and rb (pos? (inst-ms rb)))
+        (throw (ex-info (str "Refusing a non-epoch :remove-before on a Geschichte repository. "
+                             "Geschichte's refs are datoms, so Datahike cannot see them as "
+                             "roots; a cutoff would delete the commit snapshots the refs name "
+                             "and silently brick the repository.")
+                        {:type :geschichte/unsafe-gc-cutoff
+                         :remove-before rb
+                         :system system-name})))
+      (platform-async
+       (if (:dry-run? opts)
+         {:system-id system-name :dry-run? true}
+         (let [removed (await (execution/io-result (d/gc-storage conn epoch)
+                                                   execution/default-opts))]
+           {:system-id system-name
+            :reclaimed (if (counted? removed) (count removed) 0)})))))
+
   p/Overlayable
   (overlay [this _opts]
     (platform-async

--- a/test/geschichte/gc_test.clj
+++ b/test/geschichte/gc_test.clj
@@ -1,0 +1,76 @@
+(ns geschichte.gc-test
+  "GarbageCollectable for a Geschichte repository.
+
+   Two properties, and the second is the reason this implementation exists
+   rather than letting yggdrasil's generic Datahike adapter handle the store:
+
+   1. A Geschichte system participates in coordinated GC at all. Before this,
+      `GeschichteSystem` did not satisfy `GarbageCollectable`, and both of
+      yggdrasil's collection entry points SKIP systems that do not — so no
+      repository store was ever swept, by anything.
+
+   2. A non-epoch `:remove-before` is REFUSED. `:geschichte.commit/snapshot`
+      resolves through `d/commit-as-db`, so a Datahike commit record IS a Git
+      tree, and Datahike follows ancestry only while a record is newer than the
+      cutoff (its liveness rule is reachability AND recency). Geschichte's refs
+      are ordinary datoms, invisible to that rule, so under a cutoff every
+      commit looks like unreferenced old history. Measured: 3 commits + a
+      non-epoch cutoff reclaimed 75 keys, after which `tree`/`status`/`tree-at`
+      all throw \"names a missing Datahike checkpoint\" while `read` still
+      works — a silently half-destroyed repository."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [geschichte.projection :as proj]
+            [geschichte.repo :as repo]
+            [geschichte.yggdrasil :as gy]
+            [yggdrasil.protocols :as p]))
+
+(defn- with-repo [f]
+  (let [path (str "/tmp/geschichte-gc-test-" (random-uuid))
+        cfg  (assoc (proj/default-config)
+                    :store {:backend :file :path path :id (random-uuid)})]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (repo/init! conn)
+      (try (f conn)
+           (finally (d/release conn))))))
+
+(deftest geschichte-system-participates-in-gc
+  (with-repo
+    (fn [conn]
+      (repo/write! conn "a.txt" (.getBytes "hello"))
+      (repo/stage-all! conn)
+      (repo/commit! conn {:message "one" :author "t"})
+      (let [sys (gy/->GeschichteSystem conn "test-repo")]
+        (testing "the protocol is satisfied — yggdrasil's GC skips systems that don't"
+          (is (satisfies? p/GarbageCollectable sys)))
+
+        (testing "ref tips are reported as roots"
+          (let [roots (p/gc-roots sys)]
+            (is (set? roots))
+            (is (seq roots) "a repo with a commit and a ref has at least one root")))
+
+        (testing "an epoch sweep is safe and leaves the repository readable"
+          (let [r (p/gc-sweep! sys nil {})]
+            (is (= "test-repo" (:system-id r)))
+            (is (number? (:reclaimed r))))
+          (is (some? (repo/head-commit conn)))
+          (is (some? (repo/tree conn :head))))))))
+
+(deftest refuses-a-cutoff-that-would-brick-the-repository
+  (with-repo
+    (fn [conn]
+      (repo/write! conn "a.txt" (.getBytes "hello"))
+      (repo/stage-all! conn)
+      (repo/commit! conn {:message "one" :author "t"})
+      (let [sys (gy/->GeschichteSystem conn "test-repo")]
+        (testing "a non-epoch :remove-before throws rather than collecting"
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (p/gc-sweep! sys nil {:remove-before (java.util.Date.)})))
+          (is (= :geschichte/unsafe-gc-cutoff
+                 (try (p/gc-sweep! sys nil {:remove-before (java.util.Date.)})
+                      nil
+                      (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))))
+        (testing "and the repository is untouched by the refusal"
+          (is (some? (repo/head-commit conn)))
+          (is (some? (repo/tree conn :head))))))))


### PR DESCRIPTION
## Two problems, one of them silent data loss

### 1. No repository store was ever swept

`GeschichteSystem` implemented `SystemIdentity`, `Snapshotable`, `Branchable`
and `Overlayable` — but not `GarbageCollectable`. Both of yggdrasil's collection
entry points **skip** systems that don't satisfy it
([`yggdrasil/gc.cljc:68,135`]).

Datahike's index is immutable, so every transaction leaves superseded nodes
orphaned and only an explicit sweep reclaims them. A consumer running
coordinated GC across a room's stores swept everything *except* the repository.

### 2. A non-epoch cutoff destroys the repository

`:geschichte.commit/snapshot` resolves through `d/commit-as-db`, so **a Datahike
commit record IS a Git tree**. Datahike's liveness rule is reachability *and
recency* — `reachable-in-branch` follows ancestry only while a record is newer
than `remove-before`. Geschichte's refs are ordinary datoms, invisible to that
rule, so under a cutoff every commit looks like unreferenced old history.

Measured: 3 commits + a non-epoch cutoff reclaimed 75 keys, after which

```
repo/tree      -> throws "Geschichte commit names a missing Datahike checkpoint"
repo/status    -> throws
repo/tree-at   -> throws
repo/read      -> still works
```

Silent, partial destruction — the failure surfaces later, in a different
operation than the one that caused it.

## What this does

- `gc-roots` reports each ref tip's snapshot, so a coordinator can see what the
  repository considers live.
- `gc-sweep!` delegates to `d/gc-storage` at **epoch**, which is safe and
  reclaims writes published to Konserve that no transaction ever made reachable
  (interrupted pack imports, killed agents, aborted large writes).
- `gc-sweep!` **refuses** a non-epoch `:remove-before` with
  `:geschichte/unsafe-gc-cutoff`, rather than reclaiming and bricking.

## Refusal is a guard, not a solution

The real fix is upstream: Datahike needs **age-independent roots** so a
consumer's own pointers are visible to the collector. The natural form is
`:db.type/commit-ref` — which this schema's own comment already anticipates
(`schema.cljc:42-51`). Once that exists, `remove-before` stops meaning "delete
history" and starts meaning what git's reflog expiry means (*unreferenced*
things older than X may go), and this refusal can be relaxed.

A prototype of the Datahike side is in flight separately.

## Related finding, not in this PR

`:keep-history?` is **not required** by Geschichte and blocks reclamation.
Geschichte's time travel runs through the commit graph (`commit-as-db`), not
Datahike's temporal indices — there are zero uses of `as-of`/`since`/`history`
in `src/`, and the full suite passes identically with `:keep-history? false`
(102 tests / 3053 assertions, unchanged). It matters because under
`:keep-history? true` a retracted store-ref survives in the temporal AEVT and
keeps its blob whitelisted: retract-then-collect freed **0 bytes** with history
on, and **10.57 MB → 0.017 MB** with it off.

Left out deliberately — it's create-time-fixed and irreversible, so flipping a
library default is a consumer decision, not a drive-by.

## Testing

`104 tests, 3064 assertions, 0 failures` (was 102/3053). `cljfmt` clean.

The cutoff test asserts both that the refusal fires *and* that the repository is
untouched afterwards.
