### PR TITLE
feat(merge): content-level three-way merge

### DIFF
--- a/src/geschichte/merge.clj
+++ b/src/geschichte/merge.clj
@@ -46,15 +46,23 @@
   Tree values are stable logical content/mode metadata, so physical full-vs-delta
   choices cannot create conflicts. Returns a resolved `:tree` plus structural
   conflicts containing base/ours/theirs values (or `::absent` for deletion)."
-  [conn ours theirs]
-  (let [base (merge-base conn ours theirs)]
-    (when-not base
-      (throw (ex-info "Commits have no common ancestor"
-                      {:ours ours :theirs theirs})))
-    (core/plan-trees base ours theirs
-                     (repo/tree-at conn base)
-                     (repo/tree-at conn ours)
-                     (repo/tree-at conn theirs))))
+  ([conn ours theirs] (plan conn ours theirs nil))
+  ([conn ours theirs {:keys [merge-content?] :or {merge-content? true}}]
+   (let [base (merge-base conn ours theirs)]
+     (when-not base
+       (throw (ex-info "Commits have no common ancestor"
+                       {:ours ours :theirs theirs})))
+     ;; Content merging on by default: a path both sides edited in different
+     ;; places is not a conflict anyone wants reported, and leaving it off by
+     ;; default would mean every existing caller keeps arbitrating merges that
+     ;; resolve themselves. `:merge-content? false` restores the structural-only
+     ;; plan for callers that want to see raw tree divergence.
+     (core/plan-trees base ours theirs
+                      (repo/tree-at conn base)
+                      (repo/tree-at conn ours)
+                      (repo/tree-at conn theirs)
+                      (when merge-content?
+                        {:resolve-content (repo/content-merger conn)})))))
 
 (defn prepare!
   "Plan and stage a clean merge. Conflicting plans are returned unchanged and do

--- a/src/geschichte/merge/core.cljc
+++ b/src/geschichte/merge/core.cljc
@@ -45,16 +45,49 @@
   (merge-base-from-distances (ancestor-distances parents-of ours)
                              (ancestor-distances parents-of theirs)))
 
-(defn- resolve-path [path base ours theirs]
+(defn- resolve-path
+  "Resolve one path from its three tree entries.
+
+  The first three cases are decidable from the entries alone. The fourth — both
+  sides changed it — is where git does one more thing: it merges the two blobs
+  line by line and only conflicts if THAT fails. `resolve-content` is that step,
+  supplied by a caller that can read content (see `geschichte.repo/content-merger`);
+  it takes the three entries and returns a replacement entry, or nil when it
+  cannot merge them.
+
+  Without it the fourth case is a conflict, which is what this did before and
+  what it still does when no resolver is given. That is correct and coarse: two
+  people editing different parts of one file collide on every merge."
+  [path base ours theirs resolve-content]
   (cond
     (= ours theirs) {:path path :value ours}
     (= ours base) {:path path :value theirs}
     (= theirs base) {:path path :value ours}
-    :else {:path path :conflict {:base base :ours ours :theirs theirs}}))
+    :else
+    (if-let [merged (when (and resolve-content
+                               ;; a side that does not EXIST has no content to
+                               ;; merge — add/add and add/delete are structural
+                               ;; disagreements, not textual ones
+                               (not-any? #(= absent %) [base ours theirs]))
+                      (resolve-content path base ours theirs))]
+      {:path path :value merged :merged? true}
+      {:path path :conflict {:base base :ours ours :theirs theirs}})))
 
 (defn plan-trees
-  "Plan a merge from already-resolved commit IDs and immutable path maps."
-  [base-id ours-id theirs-id base-tree ours-tree theirs-tree]
+  "Plan a merge from already-resolved commit IDs and immutable path maps.
+
+  `opts` may carry `:resolve-content`, a fn `(path base ours theirs)` over tree
+  ENTRIES returning a merged entry or nil — the content-level merge git performs
+  before declaring a path conflicted. Omit it and every path both sides touched
+  conflicts, which is the historical behaviour.
+
+  This namespace stays pure: the resolver is passed in because merging content
+  means READING it, and reading needs a connection. `geschichte.repo/content-merger`
+  builds one."
+  ([base-id ours-id theirs-id base-tree ours-tree theirs-tree]
+   (plan-trees base-id ours-id theirs-id base-tree ours-tree theirs-tree nil))
+  ([base-id ours-id theirs-id base-tree ours-tree theirs-tree
+    {:keys [resolve-content]}]
   (let [paths (sort (set/union (set (keys base-tree))
                                (set (keys ours-tree))
                                (set (keys theirs-tree))))
@@ -63,7 +96,8 @@
                 (resolve-path path
                               (get base-tree path absent)
                               (get ours-tree path absent)
-                              (get theirs-tree path absent)))
+                              (get theirs-tree path absent)
+                              resolve-content))
               paths)
         conflicts (into (sorted-map)
                         (keep (fn [{:keys [path conflict]}]
@@ -78,4 +112,10 @@
                  (= base-id ours-id) :fast-forward
                  :else :merge)
      :base base-id :ours ours-id :theirs theirs-id
-     :tree tree :conflicts conflicts :clean? (empty? conflicts)}))
+     :tree tree :conflicts conflicts :clean? (empty? conflicts)
+     ;; the paths a content merge settled — a caller writing a merge commit
+     ;; message, or a reviewer, wants to know which files were reconciled
+     ;; rather than taken wholesale from one side
+     :merged (into (sorted-set) (keep (fn [{:keys [path merged?]}]
+                                        (when merged? path))
+                                      resolutions))})))

--- a/src/geschichte/merge/core.cljc
+++ b/src/geschichte/merge/core.cljc
@@ -88,34 +88,34 @@
    (plan-trees base-id ours-id theirs-id base-tree ours-tree theirs-tree nil))
   ([base-id ours-id theirs-id base-tree ours-tree theirs-tree
     {:keys [resolve-content]}]
-  (let [paths (sort (set/union (set (keys base-tree))
-                               (set (keys ours-tree))
-                               (set (keys theirs-tree))))
-        resolutions
-        (mapv (fn [path]
-                (resolve-path path
-                              (get base-tree path absent)
-                              (get ours-tree path absent)
-                              (get theirs-tree path absent)
-                              resolve-content))
-              paths)
-        conflicts (into (sorted-map)
-                        (keep (fn [{:keys [path conflict]}]
-                                (when conflict [path conflict])))
-                        resolutions)
-        tree (into (sorted-map)
-                   (keep (fn [{:keys [path value conflict]}]
-                           (when (and (nil? conflict) (not= value absent))
-                             [path value])))
-                   resolutions)]
-    {:kind (cond (= ours-id theirs-id) :up-to-date
-                 (= base-id ours-id) :fast-forward
-                 :else :merge)
-     :base base-id :ours ours-id :theirs theirs-id
-     :tree tree :conflicts conflicts :clean? (empty? conflicts)
+   (let [paths (sort (set/union (set (keys base-tree))
+                                (set (keys ours-tree))
+                                (set (keys theirs-tree))))
+         resolutions
+         (mapv (fn [path]
+                 (resolve-path path
+                               (get base-tree path absent)
+                               (get ours-tree path absent)
+                               (get theirs-tree path absent)
+                               resolve-content))
+               paths)
+         conflicts (into (sorted-map)
+                         (keep (fn [{:keys [path conflict]}]
+                                 (when conflict [path conflict])))
+                         resolutions)
+         tree (into (sorted-map)
+                    (keep (fn [{:keys [path value conflict]}]
+                            (when (and (nil? conflict) (not= value absent))
+                              [path value])))
+                    resolutions)]
+     {:kind (cond (= ours-id theirs-id) :up-to-date
+                  (= base-id ours-id) :fast-forward
+                  :else :merge)
+      :base base-id :ours ours-id :theirs theirs-id
+      :tree tree :conflicts conflicts :clean? (empty? conflicts)
      ;; the paths a content merge settled — a caller writing a merge commit
      ;; message, or a reviewer, wants to know which files were reconciled
      ;; rather than taken wholesale from one side
-     :merged (into (sorted-set) (keep (fn [{:keys [path merged?]}]
-                                        (when merged? path))
-                                      resolutions))})))
+      :merged (into (sorted-set) (keep (fn [{:keys [path merged?]}]
+                                         (when merged? path))
+                                       resolutions))})))

--- a/src/geschichte/merge/text.cljc
+++ b/src/geschichte/merge/text.cljc
@@ -1,0 +1,134 @@
+(ns geschichte.merge.text
+  "Three-way LINE merge — the content half of a merge.
+
+   `merge.core/plan-trees` resolves a path by comparing tree ENTRIES: same on
+   both sides, unchanged on one side, or a conflict. Those three cases are also
+   git's, and git then does one more thing — in the conflict case it merges the
+   two blobs LINE by line and only reports a conflict if that fails. This is
+   that step.
+
+   Without it, every path both sides touched conflicts, whether or not the
+   changes overlap. That is correct but coarse enough to matter: two people (or
+   two agents) working different parts of one file collide on every merge, and
+   each collision costs whoever has to arbitrate it.
+
+   Pure and total: lines in, lines or conflict hunks out. No connection, no IO,
+   no store. That is what keeps it here in the portable planner rather than in
+   `repo` — and it is also what makes it testable, which matters because every
+   failure mode in a merge is quiet. An off-by-one does not throw; it drops a
+   line.
+
+   The algorithm is diff3. Diff base→ours and base→theirs, express each as
+   replacements over BASE ranges, then sweep both in base order: a range only
+   one side touched is taken from that side, a range both touched is a conflict
+   unless they made the same change, everything else is base.
+
+   It does NOT resolve conflicts. Overlapping edits come back as the three
+   texts, for a caller to decide. Auto-resolving them is how a merge tool loses
+   work."
+  (:require [clojure.string :as str]
+            [geschichte.diff :as gdiff]))
+
+(defn- replacements
+  "A diff, as replacements over BASE ranges: `[{:start :end :lines} …]`, half
+   open, sorted, non-overlapping.
+
+   Adjacent delete+insert become ONE replacement rather than two edits. Kept
+   separate they read as \"deleted these lines\" and \"added those\", and two
+   sides that both rewrote one line would then look like four independent
+   changes, two of which happen to abut — which merges cleanly and produces
+   nonsense."
+  [{:keys [a-lines b-lines edits]}]
+  (let [raw (keep (fn [{:keys [op a-start a-count b-start b-count]}]
+                    (case op
+                      :equal nil
+                      :delete {:start a-start :end (+ a-start a-count) :lines []}
+                      :insert {:start a-start :end a-start
+                               :lines (subvec (vec b-lines) b-start (+ b-start b-count))}))
+                  edits)]
+    (->> raw
+         (sort-by (juxt :start :end))
+         (reduce (fn [acc {:keys [start end lines] :as r}]
+                   (if-let [prev (peek acc)]
+                     (if (<= start (:end prev))
+                       ;; touching or overlapping — one replacement
+                       (conj (pop acc)
+                             {:start (:start prev)
+                              :end (max (:end prev) end)
+                              :lines (into (:lines prev) lines)})
+                       (conj acc r))
+                     (conj acc r)))
+                 [])
+         vec)))
+
+(defn- overlaps?
+  "Do two base ranges touch? Adjacency counts: an insert at line N and a
+   replacement ending at N describe the same seam, and treating them as
+   independent interleaves the two sides' text."
+  [a b]
+  (and (<= (:start a) (:end b)) (<= (:start b) (:end a))))
+
+(defn merge-lines
+  "Three-way merge of line vectors. Returns
+
+     {:clean? true  :lines [...]}
+     {:clean? false :lines [...] :conflicts [{:base :ours :theirs} …]}
+
+   The line vector is returned either way — on a conflict it carries the
+   ours-side text at the conflicting regions, so a caller that wants to show
+   something still can, and `:conflicts` says exactly what was elided."
+  [base ours theirs]
+  (let [base (vec base) ours (vec ours) theirs (vec theirs)
+        o (replacements (gdiff/diff-lines base ours))
+        t (replacements (gdiff/diff-lines base theirs))]
+    (loop [pos 0, o o, t t, out [], conflicts []]
+      (let [oh (first o) th (first t)]
+        (cond
+          ;; nothing left to apply — the rest of base survives
+          (and (nil? oh) (nil? th))
+          (cond-> {:clean? (empty? conflicts)
+                   :lines (into out (subvec base (min pos (count base))))}
+            (seq conflicts) (assoc :conflicts conflicts))
+
+          ;; both sides touch the same region
+          (and oh th (overlaps? oh th))
+          (let [start (min (:start oh) (:start th))
+                end (max (:end oh) (:end th))]
+            (if (= (:lines oh) (:lines th))
+              ;; the SAME edit made twice is not a conflict — two agents told to
+              ;; do one thing both doing it is the expected case, not a clash
+              (recur end (rest o) (rest t)
+                     (into (into out (subvec base pos start)) (:lines oh))
+                     conflicts)
+              (recur end (rest o) (rest t)
+                     (into (into out (subvec base pos start)) (:lines oh))
+                     (conj conflicts
+                           {:base (subvec base (min start (count base))
+                                          (min end (count base)))
+                            :ours (:lines oh)
+                            :theirs (:lines th)}))))
+
+          ;; only ours, or ours comes first
+          (and oh (or (nil? th) (< (:start oh) (:start th))))
+          (recur (:end oh) (rest o) t
+                 (into (into out (subvec base pos (:start oh))) (:lines oh))
+                 conflicts)
+
+          :else
+          (recur (:end th) o (rest t)
+                 (into (into out (subvec base pos (:start th))) (:lines th))
+                 conflicts))))))
+
+(defn merge-text
+  "`merge-lines` over strings. Returns the same map with `:text` instead of
+   `:lines`.
+
+   Splits and rejoins on `\\n` rather than using `text-lines`' final-newline
+   metadata: a merge must reproduce the file's bytes, and the round trip
+   `split → join` is exact for that as long as both halves agree."
+  [base ours theirs]
+  (let [split #(if (str/blank? %) [] (str/split (or % "") #"\n" -1))
+        r (merge-lines (split base) (split ours) (split theirs))]
+    (-> r
+        (assoc :text (str/join "\n" (:lines r)))
+        (dissoc :lines))))

--- a/src/geschichte/repo.cljc
+++ b/src/geschichte/repo.cljc
@@ -11,6 +11,7 @@
             [geschichte.async :as execution]
             [geschichte.bytes :as bytes]
             [geschichte.content :as content]
+            [geschichte.merge.text :as text]
             [geschichte.query :as query]
             [geschichte.schema :as schema]
             [is.simm.partial-cps.async :refer [await]]
@@ -809,3 +810,51 @@
      (d/branch! conn (d/commit-id @conn) branch-keyword)
      execution/default-opts))
    branch-keyword))
+
+;; ---------------------------------------------------------------------------
+;; Content-level merge — the resolver `merge.core/plan-trees` takes
+;; ---------------------------------------------------------------------------
+
+(defn content-merger
+  "A `:resolve-content` fn for `merge.core/plan-trees`, bound to `conn`.
+
+  `plan-trees` decides a path from its tree entries and cannot do better on its
+  own: it holds content IDs, and merging content means reading it. This supplies
+  that half — read the three blobs, merge them line by line, store the result,
+  and hand back a tree entry pointing at it. Returns nil when the merge does not
+  settle, and the path conflicts exactly as before.
+
+  Declines rather than guesses in three cases, each of which would otherwise
+  produce a plausible-looking wrong answer: a side whose bytes are not valid
+  UTF-8 or contain a NUL (binary — line merging is meaningless), a side over
+  `max-bytes` (a merge is not the place to load an arbitrarily large blob), and
+  any entry whose `:mode` differs across the sides (a file that became a symlink
+  is not a text change).
+
+  JVM-shaped: it reads and writes synchronously, which is why it lives here
+  rather than in the portable planner."
+  ([conn] (content-merger conn nil))
+  ([conn {:keys [max-bytes] :or {max-bytes (* 1 1024 1024)}}]
+   (fn [_path base ours theirs]
+     (let [entries [base ours theirs]]
+       (when (and (apply = (map :mode entries))
+                  (every? #(<= (or (:size %) 0) max-bytes) entries))
+         (let [texts (mapv (fn [{:keys [content]}]
+                             (try
+                               (let [bs (content/read-by-id conn content)
+                                     s (when bs (bytes/decode-utf8 bs))]
+                                 (when (and s (not (str/includes? s "\u0000")))
+                                   s))
+                               (catch #?(:clj Exception :cljs :default) _ nil)))
+                           entries)]
+           (when (every? some? texts)
+             (let [[b o t] texts
+                   {:keys [clean? text]} (text/merge-text b o t)]
+               (when clean?
+                 (let [value (bytes/utf8 text)
+                       ;; store the merged bytes and take their id; no metadata
+                       ;; to transact, the tree entry below IS the reference
+                       id (content/transact-content! conn value nil (constantly []))]
+                   {:content id
+                    :size (bytes/length value)
+                    :mode (:mode ours)}))))))))))

--- a/test/geschichte/merge/content_test.clj
+++ b/test/geschichte/merge/content_test.clj
@@ -1,0 +1,161 @@
+(ns geschichte.merge.content-test
+  "`plan-trees`' content-merge hook, against a real repository.
+
+   `resolve-path` decides a path from its tree entries, and its first three
+   cases need nothing else. The fourth — both sides changed it — is where git
+   merges the two blobs before declaring a conflict, and this is that step
+   wired up: the planner stays pure and a resolver built from a connection
+   supplies the reading and writing.
+
+   What these pin is where the resolver must DECLINE. Each of those cases would
+   otherwise produce a plausible wrong answer rather than an error: binary
+   content line-merged into garbage, a mode change treated as a text edit, a
+   huge blob pulled into memory during a merge."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [geschichte.bytes :as bytes]
+            [geschichte.content :as content]
+            [geschichte.merge :as gmerge]
+            [geschichte.repo :as repo]))
+
+(defn- fresh []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write :keep-history? false :commit-graph? true}]
+    (d/create-database cfg)
+    (doto (d/connect cfg) (repo/init! {:name "merge-test"}))))
+
+(defn- commit! [conn path value msg]
+  (repo/write! conn path value)
+  (repo/stage-all! conn)
+  (repo/commit! conn {:message msg :author "test"})
+  (:geschichte.commit/id (repo/head-commit conn)))
+
+(defn- two-sided
+  "Base, then a divergent commit on each side. `f` writes each side's content.
+   Returns `[conn ours theirs]`."
+  [base-value ours-value theirs-value & [path]]
+  (let [path (or path "f.txt")
+        conn (fresh)
+        base (commit! conn path base-value "base")]
+    (repo/create-ref! conn "refs/heads/side" (repo/commit-by-id conn base))
+    (let [ours (commit! conn path ours-value "ours")]
+      (repo/checkout! conn "refs/heads/side")
+      (let [theirs (commit! conn path theirs-value "theirs")]
+        [conn ours theirs]))))
+
+(defn- text-of [conn plan path]
+  (String. (content/read-by-id conn (:content (get (:tree plan) path)))))
+
+;; ---------------------------------------------------------------------------
+
+(deftest disjoint-line-edits-no-longer-conflict
+  ;; THE case. Both sides changed one file, in different places.
+  (let [[conn ours theirs] (two-sided (bytes/utf8 "one\ntwo\nthree\nfour\n")
+                                      (bytes/utf8 "ONE\ntwo\nthree\nfour\n")
+                                      (bytes/utf8 "one\ntwo\nthree\nFOUR\n"))]
+    (testing "structurally it is a conflict, and that is what it used to be"
+      (let [p (gmerge/plan conn ours theirs {:merge-content? false})]
+        (is (not (:clean? p)))
+        (is (= ["f.txt"] (keys (:conflicts p))))))
+
+    (testing "with the content merge it resolves, carrying BOTH edits"
+      (let [p (gmerge/plan conn ours theirs)]
+        (is (:clean? p))
+        (is (= #{"f.txt"} (set (:merged p)))
+            "and says which paths it reconciled, so a caller can name them")
+        (is (= "ONE\ntwo\nthree\nFOUR\n" (text-of conn p "f.txt")))))))
+
+(deftest competing-edits-to-one-line-still-conflict
+  (let [[conn ours theirs] (two-sided (bytes/utf8 "a\nold\nc\n")
+                                      (bytes/utf8 "a\nOURS\nc\n")
+                                      (bytes/utf8 "a\nTHEIRS\nc\n"))
+        p (gmerge/plan conn ours theirs)]
+    (is (not (:clean? p)))
+    (is (= ["f.txt"] (keys (:conflicts p)))
+        "a real overlap must still reach a person — auto-resolving it is how a
+         merge tool loses work")
+    (is (empty? (:merged p)))))
+
+(deftest the-structural-cases-are-untouched
+  (testing "only one side changed the file"
+    ;; theirs diverges on a DIFFERENT path — a side that wrote the same bytes
+    ;; as base has nothing to commit, so it would not be a second branch at all
+    (let [conn (fresh)
+          base (commit! conn "f.txt" (bytes/utf8 "a\n") "base")
+          _ (repo/create-ref! conn "refs/heads/side" (repo/commit-by-id conn base))
+          ours (commit! conn "f.txt" (bytes/utf8 "CHANGED\n") "ours")
+          _ (repo/checkout! conn "refs/heads/side")
+          theirs (commit! conn "other.txt" (bytes/utf8 "unrelated\n") "theirs")
+          p (gmerge/plan conn ours theirs)]
+      (is (:clean? p))
+      (is (empty? (:merged p))
+          "resolved by the entry comparison, so the content merger never ran")
+      (is (= "CHANGED\n" (text-of conn p "f.txt")))))
+  (testing "both sides made the identical change"
+    (let [[conn ours theirs] (two-sided (bytes/utf8 "a\n")
+                                        (bytes/utf8 "SAME\n")
+                                        (bytes/utf8 "SAME\n"))
+          p (gmerge/plan conn ours theirs)]
+      (is (:clean? p))
+      (is (empty? (:merged p))))))
+
+(deftest binary-content-is-declined-not-guessed
+  ;; A NUL byte means the bytes are not lines. Merging them by line would
+  ;; produce a file that is neither side's and is not valid either.
+  (let [nul (byte-array [97 0 98 10])
+        ours (byte-array [88 0 98 10])
+        theirs (byte-array [97 0 89 10])
+        [conn o t] (two-sided nul ours theirs "blob.bin")
+        p (gmerge/plan conn o t)]
+    (is (not (:clean? p)))
+    (is (= ["blob.bin"] (keys (:conflicts p))))))
+
+(deftest an-oversized-side-is-declined
+  (let [big (apply str (repeat 300 "line of text\n"))
+        [conn ours theirs] (two-sided (bytes/utf8 big)
+                                      (bytes/utf8 (str "OURS\n" big))
+                                      (bytes/utf8 (str big "THEIRS\n")))]
+    (testing "under the ceiling it merges"
+      (is (:clean? (gmerge/plan conn ours theirs))))
+    (testing "above it the path conflicts rather than loading the blob"
+      (let [p (geschichte.merge.core/plan-trees
+               (gmerge/merge-base conn ours theirs) ours theirs
+               (repo/tree-at conn (gmerge/merge-base conn ours theirs))
+               (repo/tree-at conn ours)
+               (repo/tree-at conn theirs)
+               {:resolve-content (repo/content-merger conn {:max-bytes 10})})]
+        (is (not (:clean? p)))))))
+
+(deftest a-mode-change-is-not-a-text-change
+  ;; Same lines on both sides but different modes: the disagreement is about
+  ;; what the file IS, and a line merge has nothing to say about it.
+  (let [conn (fresh)
+        base (commit! conn "s" (bytes/utf8 "a\n") "base")]
+    (repo/create-ref! conn "refs/heads/side" (repo/commit-by-id conn base))
+    (let [ours (commit! conn "s" (bytes/utf8 "OURS\n") "ours")]
+      (repo/checkout! conn "refs/heads/side")
+      (let [theirs (commit! conn "s" (bytes/utf8 "THEIRS\n") "theirs")
+            base-c (gmerge/merge-base conn ours theirs)
+            bump (fn [tree] (update tree "s" assoc :mode 33261))
+            p (geschichte.merge.core/plan-trees
+               base-c ours theirs
+               (repo/tree-at conn base-c)
+               (bump (repo/tree-at conn ours))
+               (repo/tree-at conn theirs)
+               {:resolve-content (repo/content-merger conn)})]
+        (is (not (:clean? p))
+            "differing modes decline before any text is read")))))
+
+(deftest no-resolver-is-the-old-behaviour
+  (let [[conn ours theirs] (two-sided (bytes/utf8 "one\ntwo\n")
+                                      (bytes/utf8 "ONE\ntwo\n")
+                                      (bytes/utf8 "one\nTWO\n"))
+        base (gmerge/merge-base conn ours theirs)
+        p (geschichte.merge.core/plan-trees
+           base ours theirs
+           (repo/tree-at conn base)
+           (repo/tree-at conn ours)
+           (repo/tree-at conn theirs))]
+    (is (not (:clean? p))
+        "the six-arity plan is unchanged, so nothing that does not ask for
+         content merging can be surprised by it")))

--- a/test/geschichte/merge/text_test.clj
+++ b/test/geschichte/merge/text_test.clj
@@ -1,0 +1,134 @@
+(ns geschichte.merge.text-test
+  "diff3, exhaustively — because this is where a merge tool loses work.
+
+   `plan-trees` compares tree ENTRIES, so without a content merge two branches
+   touching one file always collide even when they edited different lines. This
+   is the function that decides which of those collisions are real.
+
+   Every case here is one a wrong implementation gets wrong QUIETLY: a dropped
+   line, a duplicated hunk, two edits interleaved into nonsense. None of them
+   throw. So the assertions are on exact output, never on a flag."
+  (:require [clojure.test :refer [deftest is testing]]
+            [geschichte.merge.text :as tm]))
+
+(defn- lines [& ls] (vec ls))
+
+(deftest disjoint-edits-merge-cleanly
+  ;; THE case this exists for: one fork edits the top, another the bottom.
+  ;; geschichte calls it a conflict; it is not one.
+  (let [base (lines "one" "two" "three" "four" "five")
+        ours (lines "ONE" "two" "three" "four" "five")
+        theirs (lines "one" "two" "three" "four" "FIVE")
+        r (tm/merge-lines base ours theirs)]
+    (is (:clean? r))
+    (is (= (lines "ONE" "two" "three" "four" "FIVE") (:lines r))
+        "both edits present, everything untouched preserved, nothing doubled")))
+
+(deftest an-untouched-file-comes-back-identical
+  (let [base (lines "a" "b" "c")
+        r (tm/merge-lines base base base)]
+    (is (:clean? r))
+    (is (= base (:lines r)))))
+
+(deftest one-sided-edits-are-taken-whole
+  (testing "only ours changed"
+    (let [base (lines "a" "b" "c")
+          r (tm/merge-lines base (lines "a" "B" "c") base)]
+      (is (:clean? r))
+      (is (= (lines "a" "B" "c") (:lines r)))))
+  (testing "only theirs changed"
+    (let [base (lines "a" "b" "c")
+          r (tm/merge-lines base base (lines "a" "b" "C"))]
+      (is (:clean? r))
+      (is (= (lines "a" "b" "C") (:lines r))))))
+
+(deftest the-same-edit-made-twice-is-not-a-conflict
+  ;; Two agents told to do one thing, both doing it. Reporting that as a clash
+  ;; would send a reviewer to arbitrate between two identical answers.
+  (let [base (lines "a" "old" "c")
+        both (lines "a" "new" "c")
+        r (tm/merge-lines base both both)]
+    (is (:clean? r))
+    (is (= both (:lines r)))))
+
+(deftest competing-edits-to-one-line-conflict
+  (let [base (lines "a" "old" "c")
+        r (tm/merge-lines base (lines "a" "OURS" "c") (lines "a" "THEIRS" "c"))]
+    (is (not (:clean? r)))
+    (is (= 1 (count (:conflicts r))))
+    (let [c (first (:conflicts r))]
+      (is (= (lines "old") (:base c)))
+      (is (= (lines "OURS") (:ours c)))
+      (is (= (lines "THEIRS") (:theirs c)))
+      "all three sides reported — a conflict a human cannot see is one they
+       can only refuse")))
+
+(deftest insertions-at-different-points-both-survive
+  (let [base (lines "a" "b" "c")
+        ours (lines "a" "OURS" "b" "c")
+        theirs (lines "a" "b" "THEIRS" "c")
+        r (tm/merge-lines base ours theirs)]
+    (is (:clean? r))
+    (is (= (lines "a" "OURS" "b" "THEIRS" "c") (:lines r)))))
+
+(deftest insertions-at-the-same-point-conflict
+  ;; Adjacency counts as overlap. Two inserts at one seam have no defensible
+  ;; order, and picking one silently is how a merge invents code nobody wrote.
+  (let [base (lines "a" "b")
+        r (tm/merge-lines base (lines "a" "OURS" "b") (lines "a" "THEIRS" "b"))]
+    (is (not (:clean? r)))
+    (is (= 1 (count (:conflicts r))))))
+
+(deftest a-deletion-on-one-side-is-applied
+  (let [base (lines "a" "b" "c")
+        r (tm/merge-lines base (lines "a" "c") base)]
+    (is (:clean? r))
+    (is (= (lines "a" "c") (:lines r)))))
+
+(deftest delete-versus-edit-of-the-same-line-conflicts
+  (let [base (lines "a" "b" "c")
+        r (tm/merge-lines base (lines "a" "c") (lines "a" "B" "c"))]
+    (is (not (:clean? r)))
+    (is (= (lines "b") (:base (first (:conflicts r)))))))
+
+(deftest edits-at-the-file-edges
+  (testing "both ends, disjoint"
+    (let [base (lines "a" "b" "c")
+          r (tm/merge-lines base (lines "A" "b" "c") (lines "a" "b" "C"))]
+      (is (:clean? r))
+      (is (= (lines "A" "b" "C") (:lines r)))))
+  (testing "append on both sides is a conflict at one seam"
+    (let [base (lines "a")
+          r (tm/merge-lines base (lines "a" "ours") (lines "a" "theirs"))]
+      (is (not (:clean? r))))))
+
+(deftest an-empty-base-with-content-on-both-sides-conflicts
+  (let [r (tm/merge-lines [] (lines "ours") (lines "theirs"))]
+    (is (not (:clean? r)))))
+
+(deftest multiple-independent-hunks-all-land
+  (let [base (lines "1" "2" "3" "4" "5" "6" "7" "8" "9")
+        ours (lines "1" "TWO" "3" "4" "5" "6" "7" "8" "9")
+        theirs (lines "1" "2" "3" "4" "FIVE" "6" "7" "EIGHT" "9")
+        r (tm/merge-lines base ours theirs)]
+    (is (:clean? r))
+    (is (= (lines "1" "TWO" "3" "4" "FIVE" "6" "7" "EIGHT" "9") (:lines r))
+        "three separate edits across two sides, none lost, none duplicated")))
+
+(deftest merge-text-round-trips-exactly
+  (testing "a clean merge reproduces the file"
+    (let [r (tm/merge-text "one\ntwo\nthree\n" "ONE\ntwo\nthree\n" "one\ntwo\nTHREE\n")]
+      (is (:clean? r))
+      (is (= "ONE\ntwo\nTHREE\n" (:text r))
+          "including the trailing newline — a merge that eats it rewrites every
+           line of the next diff")))
+  (testing "a file with no trailing newline keeps not having one"
+    (let [r (tm/merge-text "a\nb" "A\nb" "a\nb")]
+      (is (:clean? r))
+      (is (= "A\nb" (:text r))))))
+
+(deftest merge-text-reports-conflicts-and-still-returns-text
+  (let [r (tm/merge-text "x\n" "ours\n" "theirs\n")]
+    (is (not (:clean? r)))
+    (is (string? (:text r)) "callers that want to show something still can")
+    (is (seq (:conflicts r)))))


### PR DESCRIPTION
## What

`merge/core.cljc resolve-path` decides a path from its three tree **entries**: same on both sides, unchanged on one side, or a conflict. Those first three cases are also git's. The fourth is where git does one more thing — it merges the two blobs **line by line** and only reports a conflict if that fails.

We stopped at the fourth. So every path both sides touched conflicts, whether or not the changes overlap.

That is correct and coarse enough to matter. Two people editing different parts of one file collide on every merge, and each collision costs whoever has to arbitrate it. With several agents working one repository at once — simmis's case — that is *most* collisions.

## How

**`geschichte.merge.text`** — diff3 over `diff/diff-lines`, which already returns exactly the edit ranges a content merge consumes. Nothing in `diff` needed changing; this was never a diff gap.

Pure and total: lines in, lines or conflict hunks out. No connection, no store. That is what keeps it in the portable planner, and what makes it testable — every failure mode in a merge is quiet (an off-by-one does not throw, it drops a line), so the 14 tests assert on exact output rather than on flags.

**`plan-trees`** gains an optional `:resolve-content` and stays pure. The resolver is passed in rather than built here because merging content means *reading* it, and reading needs a connection.

**`repo/content-merger`** supplies that half: read the three blobs, merge, store the result, return a tree entry. It **declines rather than guesses** in three cases, each of which would otherwise produce a plausible wrong answer instead of an error:

- binary content (a NUL means the bytes are not lines)
- a side over its size ceiling (a merge is not the place to load an arbitrary blob)
- any mode difference (a file that became a symlink is not a text change)

**`merge/plan`** turns it on by default, with `:merge-content? false` for the structural-only plan. Default-on because leaving it off means every existing caller keeps arbitrating merges that resolve themselves. The six-arity `plan-trees` is untouched, so nothing that does not ask for content merging can be surprised by this.

The plan also reports `:merged`, the paths a content merge settled — a caller writing a merge message, or a reviewer, wants to know which files were reconciled rather than taken wholesale from one side.

Overlapping edits still conflict. Auto-resolving those is how a merge tool loses work.

## Verification

- `merge.text-test` — 14 tests on exact output: disjoint edits, one-sided edits, the same edit made twice, competing edits, insertions at different points vs. the same seam, delete-vs-edit, file edges, empty base, multiple independent hunks, and exact round-tripping including the trailing newline.
- `merge.content-test` — 7 tests through a real repository: the disjoint case resolving with **both** edits present, real overlaps still conflicting, the three structural cases untouched (and the merger not running for them), and each decline path.
- Full suite: **122 tests, 3094 assertions, 0 failures.**

## Origin

Built and run in simmis first, where the file-level granularity was costing a reviewer on most agent forks. It belongs here rather than there: with the hook in place `conflicts` is accurate at the source and `merge!` just works — simmis currently filters the over-reported set and invokes resolution explicitly before every land, and both of those go away for every consumer, not only simmis.