### PR TITLE
fix(merge): content-merger must write :size as a Long

### DIFF
--- a/src/geschichte/repo.cljc
+++ b/src/geschichte/repo.cljc
@@ -856,5 +856,11 @@
                        ;; to transact, the tree entry below IS the reference
                        id (content/transact-content! conn value nil (constantly []))]
                    {:content id
-                    :size (bytes/length value)
+                    ;; LONG, explicitly. `:geschichte.work/size` is
+                    ;; `:db.type/long` and datahike checks the class, so an
+                    ;; Integer here transacts fine into a plan and then throws
+                    ;; the moment that plan is APPLIED — which is why the
+                    ;; planning tests did not catch it and the adapter's
+                    ;; merge test did.
+                    :size (long (bytes/length value))
                     :mode (:mode ours)}))))))))))

--- a/test/geschichte/merge/content_test.clj
+++ b/test/geschichte/merge/content_test.clj
@@ -159,3 +159,25 @@
     (is (not (:clean? p))
         "the six-arity plan is unchanged, so nothing that does not ask for
          content merging can be surprised by it")))
+
+(deftest a-merged-plan-can-actually-be-applied
+  ;; The planning tests above stop at the plan, and a plan is not a merge. This
+  ;; one commits it — which is where a tree entry with a wrong value TYPE
+  ;; surfaces, since datahike checks the class only on transact.
+  (let [[conn ours theirs] (two-sided (bytes/utf8 "one\ntwo\nthree\nfour\n")
+                                      (bytes/utf8 "ONE\ntwo\nthree\nfour\n")
+                                      (bytes/utf8 "one\ntwo\nthree\nFOUR\n"))]
+    (repo/checkout! conn "refs/heads/main")
+    (let [p (gmerge/plan conn ours theirs)]
+      (is (:clean? p))
+      (repo/prepare-merge! conn p)
+      (repo/commit! conn {:message "merge" :author "test"})
+      (is (= "ONE\ntwo\nthree\nFOUR\n" (String. (repo/read conn "f.txt")))
+          "both edits, materialized in the worktree")
+      ;; re-resolve the tip: `head-commit` pulls the REF TARGET, and that pull
+      ;; pattern carries no `:geschichte.commit/parents` — reading parents off
+      ;; it answers 0 for every commit
+      (is (= 2 (count (:geschichte.commit/parents
+                       (repo/commit-by-id conn (:geschichte.commit/id
+                                                (repo/head-commit conn))))))
+          "and it is a real two-parent merge commit"))))


### PR DESCRIPTION
Follow-up to #9, found immediately by wiring the adapter up in yggdrasil.

## The bug

`:geschichte.work/size` is `:db.type/long` and datahike checks the class. `bytes/length` returns an Integer, so a merged tree entry transacts fine into a **plan** and throws the moment that plan is **applied**:

```
Bad entity value 19 at [:db/add 72 :geschichte.work/size 19],
value does not match schema definition. Must conform to: (= (class %) java.lang.Long)
```

So `merge/plan` looked correct and any real merge through it failed.

## Why #9's tests missed it

They stopped at the plan — they asserted on `:clean?`, on `:merged`, and on the merged blob read back by content id. None of that transacts the tree. **A plan is not a merge.** yggdrasil's adapter test caught it within minutes of being wired up, because `p/merge!` materializes.

The new test closes that gap: plan → `prepare-merge!` → commit → assert on the worktree content *and* on the two parents.

One detail in that test worth noting, since it bit me while writing it: counting parents needs the tip **re-resolved** via `commit-by-id`. `head-commit` pulls the ref target, and that pull pattern carries no `:geschichte.commit/parents`, so reading them off it answers 0 for every commit.

## Verification

- 123 tests, 3097 assertions, 0 failures
- `clj -M:format` clean