### PR TITLE
chore(name): make "ges" the spoken name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 /.shadow-cljs/
 /.internal/
 /classes/
-/gsch
-/geschichte
+/ges
 node_modules/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 **Git, as a queryable database.**
 
+*Geschichte* is German for both **history** and **story** — which is what a
+repository is. Say it **ges** (hard *g*, rhymes with *yes*); that is also the
+name of the CLI.
+
 geschichte is version control whose objects, refs, worktree, and history live in
 [Datahike](https://github.com/replikativ/datahike) and
 [Konserve](https://github.com/replikativ/konserve) — so you can commit, branch,


### PR DESCRIPTION
`geschichte` is a mouthful, and worse, it is unspellable from hearing — someone who catches the name in a talk cannot type it into a search bar. That is the real adoption tax, and it does not require a rename to fix.

The CLI has been `ges` for a while (`build.clj:71`), but the README never said so: `ges` appeared ten times as a command and exactly once in prose, buried in a subordinate clause. Nobody finished the README knowing what to call the thing out loud.

## Changes

- **README**: a paragraph under the tagline giving the German double meaning (*history* **and** *story* — which is what a repository is) and the pronunciation.
- **.gitignore**: replace the long-dead `/gsch` and `/geschichte` entries with `/ges`, which is the only binary `build.clj` emits now. Every build was showing up untracked.

## Notes

Pronunciation is written as *"hard g, rhymes with yes"* rather than *"like guess"*. Same three sounds either way, but it keeps "guess" from sitting next to a tool whose pitch is an exact, queryable record.

Dropping the stale ignore entries means anyone still holding a `gsch` or `geschichte` binary will see it as untracked — which is the point; it prompts deleting the artifact.

Renaming the project outright (`shi`, `gesta`, `lishi`) was considered and rejected: `geschichte` is the only candidate that means both history and story, it is where the German house style shared with konserve/hasch/kabel/einbetten/muschel came from, and it has zero SEO competition.